### PR TITLE
Fix #18 Memory Leak in operator=

### DIFF
--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -351,18 +351,51 @@ pngwriter::pngwriter(int x, int y, double backgroundcolour, char * filename)
 
 };
 
+void pngwriter::deleteMembers()
+{
+   if( filename_ )
+   {
+     delete [] filename_;
+     filename_ = NULL;
+   }
+   if( textauthor_ )
+   {
+     delete [] textauthor_;
+     textauthor_ = NULL;
+   }
+   if( textdescription_ )
+   {
+      delete [] textdescription_;
+      textdescription_ = NULL;
+   }
+   if( texttitle_ )
+   {
+      delete [] texttitle_;
+      texttitle_ = NULL;
+   }
+   if( textsoftware_ )
+   {
+      delete [] textsoftware_;
+      textsoftware_ = NULL;
+   }
+
+   for (int jjj = 0; jjj < height_; jjj++)
+   {
+      free(graph_[jjj]);
+      graph_[jjj] = NULL;
+   }
+   if( graph_ )
+   {
+      free(graph_);
+      graph_ = NULL;
+   }
+}
+
 //Destructor
 ///////////////////////////////////////
 pngwriter::~pngwriter()
 {
-   delete [] filename_;
-   delete [] textauthor_;
-   delete [] textdescription_;
-   delete [] texttitle_;
-   delete [] textsoftware_;
-
-   for (int jjj = 0; jjj < height_; jjj++) free(graph_[jjj]);
-   free(graph_);
+   deleteMembers();
 };
 
 //Constructor for int levels, const char * filename
@@ -542,9 +575,10 @@ pngwriter::pngwriter(int x, int y, double backgroundcolour, const char * filenam
 pngwriter & pngwriter::operator = (const pngwriter & rhs)
 {
    if( this==&rhs)
-     {
-	return *this;
-     }
+      return *this;
+
+   // free old allocations from member variables
+   deleteMembers();
 
    width_ = rhs.width_;
    height_ = rhs.height_;

--- a/src/pngwriter.h
+++ b/src/pngwriter.h
@@ -146,6 +146,8 @@ class pngwriter
    void drawbottom_blend(long x1,long y1,long x2,long x3,long y3, double opacity, int red, int green, int blue);
    void drawtop_blend(long x1,long y1,long x2,long y2,long x3, double opacity, int red, int green, int blue);
    
+   /* free up memory of member variables and reset internal pointers to NULL */
+   void deleteMembers();
  public:
 
    /* General Notes


### PR DESCRIPTION
@individual61 I did some further investigation and used a more clean method than the one you guys proposed in [1] :)

The memory has to be freed **first** and than assigning _new heights, widths, ..._ is valid.
### Changes
- free internal variables before assigning new values
- use a reusable private member function now
- first report by Ahnfelt and further investigation done by Paul -> thanks!! :sparkles: 
- see [sourceforge#forum#c7607b9b](http://sourceforge.net/p/pngwriter/discussion/238247/thread/c7607b9b/)
