### PR TITLE
Test against new libpng 1.6.12 Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - LIBPNG_VERSION=1.2.51
     - LIBPNG_VERSION=1.4.13
     - LIBPNG_VERSION=1.5.18
-    - LIBPNG_VERSION=1.6.10
+    - LIBPNG_VERSION=1.6.12
 
 script:
   - cd $BUILD


### PR DESCRIPTION
Updates travis tests to use `1.6.12` in the libpng 1.6.x runs.
