### PR TITLE
Switch -lpng and -lpngwriter libraries

### DIFF
--- a/make.include.linux
+++ b/make.include.linux
@@ -36,7 +36,7 @@ CXXFLAGS= -O3 -Wall -Wno-deprecated $(FT_ARG)
 
 INC=  -I../src/ -I$(PREFIX)/include/
 
-LIBS= -L../src -L$(PREFIX)/lib/ -lz -lpng -lpngwriter
+LIBS= -L../src -L$(PREFIX)/lib/ -lz -lpngwriter -lpng
 
 INSTALL=install
 


### PR DESCRIPTION
With the prior order: -lpng -lpngwriter I got several errors like
/pngwriter.cc:1540: undefined reference to `png_create_read_struct'
when compiling the examples using cygwin.
