### PR TITLE
Close #37 Remove Freshmeat Links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 #   Website: Main:             http://pngwriter.sourceforge.net/
 #            GitHub.com:       https://github.com/ax3l/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-#            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 #
 #
 #    Author:                    Paul Blackburn https://github.com/individual61

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -3,7 +3,6 @@
 #   Website: Main:             http://pngwriter.sourceforge.net/
 #            GitHub.com:       https://github.com/ax3l/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-#            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 #
 #
 #    Author:                    Paul Blackburn https://github.com/individual61

--- a/doc/LICENSE
+++ b/doc/LICENSE
@@ -3,7 +3,6 @@
 #   Website: Main:             http://pngwriter.sourceforge.net/
 #            GitHub.com:       https://github.com/ax3l/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-#            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 #
 #
 #    Author:                    Paul Blackburn https://github.com/individual61

--- a/doc/README
+++ b/doc/README
@@ -3,7 +3,6 @@
 #   Website: Main:             http://pngwriter.sourceforge.net/
 #            GitHub.com:       https://github.com/ax3l/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-#            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 #
 #
 #    Author:                    Paul Blackburn https://github.com/individual61
@@ -182,10 +181,6 @@ and
 http://sourceforge.net/projects/pngwriter/
 and
 https://github.com/ax3l/pngwriter
-
-You can also stay updated by checking PNGwriter's freshmeat.net page:
-
-http://freshmeat.net/projects/pngwriter/
 
 
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -3,7 +3,6 @@
 #   Website: Main:             http://pngwriter.sourceforge.net/
 #            GitHub.com:       https://github.com/ax3l/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-#            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 #
 #
 #    Author:                    Paul Blackburn https://github.com/individual61

--- a/examples/lyapunov.cc
+++ b/examples/lyapunov.cc
@@ -3,7 +3,6 @@
 *   Website: Main:             http://pngwriter.sourceforge.net/
 *            GitHub.com:       https://github.com/ax3l/pngwriter
 *            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-*            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 *
 *
 *    Author:                    Paul Blackburn https://github.com/individual61

--- a/examples/pngtest.cc
+++ b/examples/pngtest.cc
@@ -3,7 +3,6 @@
 *   Website: Main:             http://pngwriter.sourceforge.net/
 *            GitHub.com:       https://github.com/ax3l/pngwriter
 *            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-*            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 *
 *
 *    Author:                    Paul Blackburn https://github.com/individual61

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,6 @@
 #   Website: Main:             http://pngwriter.sourceforge.net/
 #            GitHub.com:       https://github.com/ax3l/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-#            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 #
 #
 #    Author:                    Paul Blackburn https://github.com/individual61

--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -3,7 +3,6 @@
 *   Website: Main:             http://pngwriter.sourceforge.net/
 *            GitHub.com:       https://github.com/ax3l/pngwriter
 *            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-*            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 *
 *
 *    Author:                    Paul Blackburn https://github.com/individual61

--- a/src/pngwriter.h
+++ b/src/pngwriter.h
@@ -3,7 +3,6 @@
 *   Website: Main:             http://pngwriter.sourceforge.net/
 *            GitHub.com:       https://github.com/ax3l/pngwriter
 *            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
-*            Freshmeat.net:    http://freshmeat.net/projects/pngwriter/
 *
 *
 *    Author:                    Paul Blackburn https://github.com/individual61


### PR DESCRIPTION
[Freshmeat](http://freshmeat.net/) has been superseded by [freecode](http://freecode.com) which will be quasi-automatic anyway at some point.
