### PR TITLE
Change GitHub Links to New Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Not done yet :)
 This release fixes several bugs, removes Spanish language documentation and example files, and restructures the documentation file locations as a result of these changes.
 
 All closed issues can be found at
-  [Milestone 0.5.5](https://github.com/ax3l/pngwriter/issues?milestone=1&state=closed)
+  [Milestone 0.5.5](https://github.com/pngwriter/pngwriter/issues?milestone=1&state=closed)
 
 ### Changes to 0.5.4
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ########################## PNGwriter #########################################
 #
 #   Website: Main:             http://pngwriter.sourceforge.net/
-#            GitHub.com:       https://github.com/ax3l/pngwriter
+#            GitHub.com:       https://github.com/pngwriter/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 #
 #

--- a/README.md
+++ b/README.md
@@ -1,26 +1,19 @@
-PNGwriter Fork
-==============
+PNGwriter
+=========
 
-This repository contains an unoffical fork from the
+This repository contains the migrated repositories from
   http://pngwriter.sourceforge.net/
-repository, Version **0.5.4**.
-
-Since PNGwriter did not change since 2009 but contains minor
-bugs / flaws, this fork tries to make our lives nicer (wuhu).
-
-~~Hopefully, the changes will be merged back :)~~
-We (@ax3l and @individual61) are right now preparing a bug fix release
-0.5.5 - stay tuned!
+that are now maintained on GitHub.
 
 ### Build Status
 
-| master branch | 0.5.5 release branch |
+| master branch | development branch |
 |:-------------:|:--------------------:|
-| [![Build Status Master](https://travis-ci.org/ax3l/pngwriter.png?branch=master)](https://travis-ci.org/ax3l/pngwriter "master") | [![Build Status 0.5.5 Release Branch](https://travis-ci.org/ax3l/pngwriter.png?branch=release-0.5.5)](https://travis-ci.org/ax3l/pngwriter "0.5.5 release branch") |
+| [![Build Status Master](https://travis-ci.org/pngwriter/pngwriter.png?branch=master)](https://travis-ci.org/pngwriter/pngwriter "master") | [![Build Status Development Branch](https://travis-ci.org/pngwriter/pngwriter.png?branch=dev)](https://travis-ci.org/pngwriter/pngwriter "development branch") |
 
 ### Install
 
-- `git clone https://github.com/ax3l/pngwriter.git`
+- `git clone https://github.com/pngwriter/pngwriter.git`
 - `mkdir -p build && cd build`
 - `cmake ../pngwriter`
 - `make install` (creates the libs in `lib/` and a `pngwriter.h` in `include/`)
@@ -53,7 +46,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)
 #set(PNGwriter_USE_STATIC_LIBS ON)
 
 #   optional: specifiy (minimal) version / require to find it
-#           (PNGwriter 0.5.4 REQUIRED)
+#           (PNGwriter 0.5.5 REQUIRED)
 find_package(PNGwriter)
 
 if(PNGwriter_FOUND)
@@ -72,9 +65,7 @@ endif(PNGwriter_FOUND)
 
 ### License
 
-*Paul Blackburn* (kudos!) released this software under **GPLv2+**.
-
-Please see the original [README](README) files.
+This software is released under **GPLv2+**.
 
 ### Changes
 

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -1,7 +1,7 @@
 ########################## PNGwriter #########################################
 #
 #   Website: Main:             http://pngwriter.sourceforge.net/
-#            GitHub.com:       https://github.com/ax3l/pngwriter
+#            GitHub.com:       https://github.com/pngwriter/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 #
 #

--- a/doc/LICENSE
+++ b/doc/LICENSE
@@ -1,7 +1,7 @@
 ########################## PNGwriter #########################################
 #
 #   Website: Main:             http://pngwriter.sourceforge.net/
-#            GitHub.com:       https://github.com/ax3l/pngwriter
+#            GitHub.com:       https://github.com/pngwriter/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 #
 #

--- a/doc/README
+++ b/doc/README
@@ -1,7 +1,7 @@
 ########################## PNGwriter #########################################
 #
 #   Website: Main:             http://pngwriter.sourceforge.net/
-#            GitHub.com:       https://github.com/ax3l/pngwriter
+#            GitHub.com:       https://github.com/pngwriter/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 #
 #
@@ -180,7 +180,7 @@ http://pngwriter.sourceforge.net/
 and
 http://sourceforge.net/projects/pngwriter/
 and
-https://github.com/ax3l/pngwriter
+https://github.com/pngwriter/pngwriter
 
 
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
 ########################## PNGwriter #########################################
 #
 #   Website: Main:             http://pngwriter.sourceforge.net/
-#            GitHub.com:       https://github.com/ax3l/pngwriter
+#            GitHub.com:       https://github.com/pngwriter/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 #
 #

--- a/examples/lyapunov.cc
+++ b/examples/lyapunov.cc
@@ -1,7 +1,7 @@
 /********************************* PNGwriter **********************************
 *
 *   Website: Main:             http://pngwriter.sourceforge.net/
-*            GitHub.com:       https://github.com/ax3l/pngwriter
+*            GitHub.com:       https://github.com/pngwriter/pngwriter
 *            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 *
 *

--- a/examples/pngtest.cc
+++ b/examples/pngtest.cc
@@ -1,7 +1,7 @@
 /********************************* PNGwriter **********************************
 *
 *   Website: Main:             http://pngwriter.sourceforge.net/
-*            GitHub.com:       https://github.com/ax3l/pngwriter
+*            GitHub.com:       https://github.com/pngwriter/pngwriter
 *            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 *
 *

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 ########################## PNGwriter #########################################
 #
 #   Website: Main:             http://pngwriter.sourceforge.net/
-#            GitHub.com:       https://github.com/ax3l/pngwriter
+#            GitHub.com:       https://github.com/pngwriter/pngwriter
 #            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 #
 #

--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -1,7 +1,7 @@
 /********************************* PNGwriter **********************************
 *
 *   Website: Main:             http://pngwriter.sourceforge.net/
-*            GitHub.com:       https://github.com/ax3l/pngwriter
+*            GitHub.com:       https://github.com/pngwriter/pngwriter
 *            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 *
 *

--- a/src/pngwriter.h
+++ b/src/pngwriter.h
@@ -1,7 +1,7 @@
 /********************************* PNGwriter **********************************
 *
 *   Website: Main:             http://pngwriter.sourceforge.net/
-*            GitHub.com:       https://github.com/ax3l/pngwriter
+*            GitHub.com:       https://github.com/pngwriter/pngwriter
 *            Sourceforge.net:  http://sourceforge.net/projects/pngwriter/
 *
 *

--- a/tests/blackwhite.cc
+++ b/tests/blackwhite.cc
@@ -4,7 +4,7 @@
   *
   * License: GPLv2+
   *
-  * https://github.com/ax3l/pngwriter/issues/13
+  * https://github.com/pngwriter/pngwriter/issues/13
   */
 
 #include <pngwriter.h>


### PR DESCRIPTION
Replaces my repo with the pngwriter/pngwriter group/repo link.

I will change the ownership of the repo afterwards.

Do you have a nice logo for our `pngwriter` group? :)
