### PR TITLE
MacOSX: PNG Include Was Broken

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/")
 #
 # external library: libPNG (mandatory)
 FIND_PACKAGE(PNG 1.2.9 REQUIRED)
-INCLUDE_DIRECTORIES(${PNG_INCLUDE_PATH})
+INCLUDE_DIRECTORIES(${PNG_INCLUDE_DIRS})
 
 # external library: zlib (mandatory)
 FIND_PACKAGE(ZLIB REQUIRED)


### PR DESCRIPTION
- wrong var name, should be _DIRS since a long time:
  https://github.com/Kitware/CMake/commit/df0f302485c6f93a473e1958830b69b9c165b01a#diff-75b9f97116a34c6419fe4975ac4d6b7b
