### PR TITLE
Travis: Update to latest libpng versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ env:
     - LIBPNG_VERSION=1.4.16
     - LIBPNG_VERSION=1.5.22
     - LIBPNG_VERSION=1.6.17
-    - LIBPNG_VERSION=1.7.0beta59
+
+matrix:
+  allow_failures:
+    - env: LIBPNG_VERSION=1.7.0beta59
 
 script:
   - cd $BUILD

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ env:
     - BUILD=~/buildTmp
     - LIBPNG_DOWNLOAD=http://download.sourceforge.net/libpng/libpng-
   matrix:
-    - LIBPNG_VERSION=1.2.51
-    - LIBPNG_VERSION=1.4.13
-    - LIBPNG_VERSION=1.5.18
-    - LIBPNG_VERSION=1.6.12
+    - LIBPNG_VERSION=1.2.53
+    - LIBPNG_VERSION=1.4.16
+    - LIBPNG_VERSION=1.5.22
+    - LIBPNG_VERSION=1.6.17
+    - LIBPNG_VERSION=1.7.0beta59
 
 script:
   - cd $BUILD


### PR DESCRIPTION
Travis: Update to latest libpng versions:

- 1.2.51 -> .53
- 1.4.13 -> .16
- 1.5.18 -> .22
- 1.6.12 -> .17
- new: 1.7.0beta59 (add matrix "allow fail"?)