### PR TITLE
Close #11 Use new Convert to RFC1123

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ env:
     - LIBPNG_VERSION=1.6.17
     - LIBPNG_VERSION=1.7.0beta59
 
-matrix:
-  allow_failures:
-    - env: LIBPNG_VERSION=1.7.0beta59
-
 script:
   - cd $BUILD
   - cmake $TRAVIS_BUILD_DIR
@@ -43,3 +39,8 @@ before_script:
   - sudo make install
   - sudo find /usr/lib -name 'libpng*'
   - mkdir -p $BUILD
+
+after_script:
+  - cp -R $TRAVIS_BUILD_DIR/examples/burro.png .
+  - export LD_LIBRARY_PATH=`pwd`:$LD_LIBRARY_PATH
+  - ./pngtest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All closed issues can be found at
 ### Changes to 0.5.4
 
 **New Features:**
-  - support for libpng 1.4, 1.5 and 1.6 #10 #11
+  - support for libpng 1.4.X, 1.5.X, 1.6.X and 1.7.0beta59 #10 #11 #54
     (thanks to Daniel Hornung http://sourceforge.net/p/pngwriter/bugs/1 for the 1.4 patch)
   - added alternative cmake based install via `CMakeLists.txt`
   - cmake: build the *static* archive **and** a *shared* library

--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -1076,11 +1076,15 @@ void pngwriter::close()
    char key_create[] = "Creation Time";
    text_ptr[4].key = key_create;
    char textcrtime[29] = "tIME chunk is not present...";
+#if (PNG_LIBPNG_VER < 10600)
    textcrtime[28] = '\0';
    memcpy(textcrtime,
           png_convert_to_rfc1123(png_ptr, &mod_time),
           29);
    textcrtime[sizeof(text_ptr[4].text) - 1] = '\0';
+#else
+   png_convert_to_rfc1123_buffer(textcrtime, &mod_time);
+#endif
    text_ptr[4].text = textcrtime;
    text_ptr[4].compression = PNG_TEXT_COMPRESSION_NONE;
    entries++;


### PR DESCRIPTION
- removes deprecated warning when used with libpng 1.6.X
- adds initial support for libpng 1.7.0beta59