### PR TITLE
libpng 1.6+: No transforms after png_read_update_info

### DIFF
--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -1535,15 +1535,9 @@ aliases
      }
 
    screengamma_ = 2.2;
-   double          file_gamma,screen_gamma;
-   screen_gamma = screengamma_;
-   if (png_get_gAMA(png_ptr, info_ptr, &file_gamma))
+   double          file_gamma;
+   if (!png_get_gAMA(png_ptr, info_ptr, &file_gamma))
      {
-	png_set_gamma(png_ptr,screen_gamma,file_gamma);
-     }
-   else
-     {
-	png_set_gamma(png_ptr, screen_gamma,0.45);
         file_gamma=0.45;
      }
 


### PR DESCRIPTION
From the changelog of libpng 1.5.X to 1.6.X:
```
  The library now issues an error if the application attempts to set a
transform after it calls `png_read_update_info()` or if it attempts to call
both `png_read_update_info()` and `png_start_read_image()` or to call either
of them more than once.
```
  http://www.libpng.org/pub/png/libpng-manual.txt

Probably, the transforms after `png_read_update_info()` never were written to the file and due to that never took effect...

```
Information about your system

If you intend to display the PNG or to incorporate it in other image data you
need to tell libpng information about your display or drawing surface so that
libpng can convert the values in the image to match the display.

From libpng-1.5.4 this information can be set before reading the PNG file
header.  In earlier versions png_set_gamma() existed but behaved incorrectly if
called before the PNG file header had been read and png_set_alpha_mode() did not
exist.

If you need to support versions prior to libpng-1.5.4 test the version number
as illustrated below using "PNG_LIBPNG_VER >= 10504" and follow the procedures
described in the appropriate manual page.

You give libpng the encoding expected by your system expressed as a 'gamma'
value.  You can also specify a default encoding for the PNG file in
case the required information is missing from the file.  By default libpng
assumes that the PNG data matches your system, to keep this default call:

   png_set_gamma(png_ptr, screen_gamma, output_gamma);
[...]
```

First seen in https://travis-ci.org/pngwriter/pngwriter/jobs/59598155 running `pngtest` which uses `readfromfile` to read `burro.png`