### PR TITLE
CMake: Add more Warnings, Travis: -Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ compiler:
 
 env:
   global:
+    - CXXFLAGS="-Werror"
     - BUILD=~/buildTmp
     - LIBPNG_DOWNLOAD=http://download.sourceforge.net/libpng/libpng-
   matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,25 @@ ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 # set helper pathes to find libraries and packages on some 64bit machines
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/")
 
+# Warnings ####################################################################
+#
+# GNU
+IF(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
+# Clang
+ELSEIF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
+# ICC
+ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
+# PGI
+ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minform=inform")
+ENDIF()
 
 # Dependencies ################################################################
 #

--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -2336,11 +2336,11 @@ void pngwriter::plot_text_utf8( char * face_path, int fontsize, int x_start, int
 void pngwriter::my_draw_bitmap( FT_Bitmap * bitmap, int x, int y, double red, double green, double blue)
 {
    double temp;
-   for(int j=1; j<bitmap->rows+1; j++)
+   for(unsigned int j = 1u; j < bitmap->rows + 1u; j++)
      {
-	for(int i=1; i< bitmap->width + 1; i++)
+	for(unsigned int i = 1u; i < bitmap->width + 1u; i++)
 	  {
-	     temp = (double)(bitmap->buffer[(j-1)*bitmap->width + (i-1)] )/255.0;
+	     temp = (double)(bitmap->buffer[(j-1u)*bitmap->width + (i-1u)] )/255.0;
 
 	     if(temp)
 	       {
@@ -4082,11 +4082,11 @@ void pngwriter::plot_text_utf8_blend( char * face_path, int fontsize, int x_star
 void pngwriter::my_draw_bitmap_blend( FT_Bitmap * bitmap, int x, int y, double opacity, double red, double green, double blue)
 {
    double temp;
-   for(int j=1; j<bitmap->rows+1; j++)
+   for(unsigned int j = 1u; j < bitmap->rows + 1u; j++)
      {
-	for(int i=1; i< bitmap->width + 1; i++)
+	for(unsigned int i = 1u; i < bitmap->width + 1u; i++)
 	  {
-	     temp = (double)(bitmap->buffer[(j-1)*bitmap->width + (i-1)] )/255.0;
+	     temp = (double)(bitmap->buffer[(j-1u)*bitmap->width + (i-1u)] )/255.0;
 
 	     if(temp)
 	       {


### PR DESCRIPTION
Adds a useful set of warnings for
- GCC
- Clang
- ICC
- PGI

Additionally, travis will now perform tests with `-Werror` enabled to enforce those.