### PR TITLE
libpng 1.7beta65 was released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ env:
     - LIBPNG_VERSION=1.4.16
     - LIBPNG_VERSION=1.5.22
     - LIBPNG_VERSION=1.6.17
-    - LIBPNG_VERSION=1.7.0beta64
+    - LIBPNG_VERSION=1.7.0beta65
 
 matrix:
   allow_failures:
-    - env: LIBPNG_VERSION=1.7.0beta64
+    - env: LIBPNG_VERSION=1.7.0beta65
 
 script:
   - cd $BUILD


### PR DESCRIPTION
Updates travis to test the new beta of libpng correctly.