### PR TITLE
Remove Private Member `rowbytes_`

### DIFF
--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -1464,8 +1464,6 @@ void pngwriter::readfromfile(char * name)
    //Graph now is the image.
    graph_ = image;
 
-   rowbytes_ = png_get_rowbytes(png_ptr, info_ptr);
-
 	// This was part of the original source, but has been moved up.
 /*
    png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type, &interlace_type, NULL, NULL);

--- a/src/pngwriter.h
+++ b/src/pngwriter.h
@@ -96,7 +96,6 @@ class pngwriter
    int width_;
    int  backgroundcolour_;
    int bit_depth_;
-   int rowbytes_;
    int colortype_;
    int compressionlevel_;
    bool transformation_; // Required by Mikkel's patch


### PR DESCRIPTION
This removes the unused and most of the time uninitialized private member `rowbytes_`. The call to `png_get_rowbytes` has now side-effects and should be save to be removed, too.

Fixes Coverity CID 114036-114041