### PR TITLE
Close #76 Creation Time Could be Wrong

### DIFF
--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -1077,14 +1077,13 @@ void pngwriter::close()
    text_ptr[4].key = key_create;
    char textcrtime[29] = "tIME chunk is not present...";
 #if (PNG_LIBPNG_VER < 10600)
-   textcrtime[28] = '\0';
    memcpy(textcrtime,
           png_convert_to_rfc1123(png_ptr, &mod_time),
           29);
-   textcrtime[sizeof(text_ptr[4].text) - 1] = '\0';
 #else
    png_convert_to_rfc1123_buffer(textcrtime, &mod_time);
 #endif
+   textcrtime[sizeof(textcrtime) - 1] = '\0';
    text_ptr[4].text = textcrtime;
    text_ptr[4].compression = PNG_TEXT_COMPRESSION_NONE;
    entries++;


### PR DESCRIPTION
Close #76 Due to a `strlen()` check of an undefined variable (uninitialized [char pointer member `text`](https://github.com/glennrp/libpng/blob/libpng12/png.h#L505-L506) of `struct png_text`), the creation time meta data string could sometimes accidentally be cropped.

Also, there is the slight possibility that [some random byte](https://github.com/pngwriter/pngwriter/blob/0.5.5/src/pngwriter.cc#L1084) behind a certain position (where [this](https://github.com/pngwriter/pngwriter/blob/0.5.5/src/pngwriter.cc#L1078) is stored) is set to `\0`, depending on what `sizeof()` from an undefined variable gives back.

The bug was introduced in the `0.5.5` release with 1baf8ed6676873935cf4fba1440b212d667d8295

fun fact: not found by `llvm`'s `scan-build` (3.5) nor by `coverity` (2015)