### PR TITLE
Close #80 Unused Parameters (No-Freetype)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,11 @@ env:
     - BUILD=~/buildTmp
     - LIBPNG_DOWNLOAD=http://download.sourceforge.net/libpng/libpng-
   matrix:
-    - LIBPNG_VERSION=1.2.53
-    - LIBPNG_VERSION=1.4.16
-    - LIBPNG_VERSION=1.5.22
-    - LIBPNG_VERSION=1.6.17
+    - LIBPNG_VERSION=1.2.53 FREETYPE=ON
+    - LIBPNG_VERSION=1.2.53 FREETYPE=OFF
+    - LIBPNG_VERSION=1.4.16 FREETYPE=ON
+    - LIBPNG_VERSION=1.5.22 FREETYPE=ON
+    - LIBPNG_VERSION=1.6.17 FREETYPE=ON
     - LIBPNG_VERSION=1.7.0beta65
 
 matrix:
@@ -25,6 +26,10 @@ script:
   - cmake $TRAVIS_BUILD_DIR
   - make
   - sudo make install
+# tests
+  - cp -R $TRAVIS_BUILD_DIR/examples/burro.png .
+  - export LD_LIBRARY_PATH=`pwd`:$LD_LIBRARY_PATH
+  - ./pngtest
 
 before_script:
   - uname -r
@@ -32,7 +37,8 @@ before_script:
 # kick without checking dependencies
   - sudo dpkg -r --force-depends libpng12-dev
   - sudo dpkg -r --force-depends libpng12-0
-  - sudo rm -rf /usr/include/libpng12 /urs/include/png*.h /usr/lib/x86_64-linux-gnu/libpng*
+  - if [ "$FREETYPE" == "OFF" ]; then sudo dpkg -r --force-depends libfreetype6; sudo rm -rf /usr/include/freetype* /usr/lib/x86_64-linux-gnu/libfreetype*; fi
+  - sudo rm -rf /usr/include/libpng12 /usr/include/png*.h /usr/lib/x86_64-linux-gnu/libpng*
 #  - sudo apt-get remove -qq libpng12-0 libpng12-0:i386
   - sudo dpkg --get-selections
   - wget "$LIBPNG_DOWNLOAD$LIBPNG_VERSION.tar.xz"
@@ -44,8 +50,3 @@ before_script:
   - sudo make install
   - sudo find /usr/lib -name 'libpng*'
   - mkdir -p $BUILD
-
-after_script:
-  - cp -R $TRAVIS_BUILD_DIR/examples/burro.png .
-  - export LD_LIBRARY_PATH=`pwd`:$LD_LIBRARY_PATH
-  - ./pngtest

--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -2727,40 +2727,40 @@ int pngwriter::get_text_width_utf8(char * face_path, int fontsize,  char * text)
 #endif
 #ifdef NO_FREETYPE
 
-void pngwriter::plot_text( char * face_path, int fontsize, int x_start, int y_start, double angle, char * text, int red, int green, int blue)
+void pngwriter::plot_text( char *, int, int, int, double, char *, int, int, int )
 {
    std::cerr << " PNGwriter::plot_text - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return;
 }
 
-void pngwriter::plot_text( char * face_path, int fontsize, int x_start, int y_start, double angle, char * text, double red, double green, double blue)
+void pngwriter::plot_text( char *, int, int, int, double, char *, double, double, double )
 {
    std::cerr << " PNGwriter::plot_text - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return;
 
 }
 
-void pngwriter::plot_text_utf8( char * face_path, int fontsize, int x_start, int y_start, double angle, char * text, int red, int green, int blue)
+void pngwriter::plot_text_utf8( char *, int, int, int, double, char *, int, int, int )
 {
    std::cerr << " PNGwriter::plot_text_utf8 - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return;
 }
 
-void pngwriter::plot_text_utf8( char * face_path, int fontsize, int x_start, int y_start, double angle, char * text, double red, double green, double blue)
+void pngwriter::plot_text_utf8( char *, int, int, int, double, char *, double, double, double)
 {
    std::cerr << " PNGwriter::plot_text_utf8 - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return;
 }
 
 //////////// Get text width
-int pngwriter::get_text_width(char * face_path, int fontsize, char * text)
+int pngwriter::get_text_width(char *, int, char *)
 {
    std::cerr << " PNGwriter::get_text_width - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return 0;
 }
 
 
-int pngwriter::get_text_width_utf8(char * face_path, int fontsize,  char * text)
+int pngwriter::get_text_width_utf8(char *, int,  char *)
 {
    std::cerr << " PNGwriter::get_text_width_utf8 - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return 0;
@@ -4156,26 +4156,26 @@ void pngwriter::my_draw_bitmap_blend( FT_Bitmap * bitmap, int x, int y, double o
 #endif
 #ifdef NO_FREETYPE
 
-void pngwriter::plot_text_blend( char * face_path, int fontsize, int x_start, int y_start, double angle, char * text, double opacity, int red, int green, int blue)
+void pngwriter::plot_text_blend( char *, int, int, int, double, char *, double, int, int, int )
 {
    std::cerr << " PNGwriter::plot_text_blend - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return;
 }
 
-void pngwriter::plot_text_blend( char * face_path, int fontsize, int x_start, int y_start, double angle, char * text, double opacity,  double red, double green, double blue)
+void pngwriter::plot_text_blend( char *, int, int, int, double, char *, double,  double, double, double )
 {
    std::cerr << " PNGwriter::plot_text_blend - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return;
 
 }
 
-void pngwriter::plot_text_utf8_blend( char * face_path, int fontsize, int x_start, int y_start, double angle, char * text, double opacity,  int red, int green, int blue)
+void pngwriter::plot_text_utf8_blend( char *, int, int, int, double, char *, double,  int, int, int )
 {
    std::cerr << " PNGwriter::plot_text_utf8_blend - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return;
 }
 
-void pngwriter::plot_text_utf8_blend( char * face_path, int fontsize, int x_start, int y_start, double angle, char * text, double opacity, double red, double green, double blue)
+void pngwriter::plot_text_utf8_blend( char *, int, int, int, double, char *, double, double, double, double )
 {
    std::cerr << " PNGwriter::plot_text_utf8_blend - ERROR **:  PNGwriter was compiled without Freetype support! Recompile PNGwriter with Freetype support (once you have Freetype installed, that is. Websites: www.freetype.org and pngwriter.sourceforge.net)." << std::endl;
    return;


### PR DESCRIPTION
Close #80 by removing the unused parameters in the no-freetype version of PNGwriter.