### PR TITLE
Fix #89 8bit Read: Correct Range

### DIFF
--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -765,6 +765,14 @@ int pngwriter::read(int x, int y, int colour) const
 
 	if(bit_depth_ == 16)
 	  {
+	     /* In these cases *256 is correct, because what we actually are
+          * doing is bitshifting by 8 bit and then appending the next lower
+          * 8 bit.
+          * These lines are inefficient. Bitshifting and bitwise anding may
+          * have better performance than multiplication and addition.
+          * We could also just convert (unsigned char*) to (uint16_t*).
+          * If the open file function does it in the same way, then this
+          * method makes no assumptions about platform endianness */
 	     temp2=6*(x-1);
 	     if(colour == 1)
 	       {
@@ -787,23 +795,24 @@ int pngwriter::read(int x, int y, int colour) const
 
 	if(bit_depth_ == 8)
 	  {
+	     int const scale8To16Bit = 257;   // x/255*65535 = x*257
 	     temp2=3*(x-1);
 	     if(colour == 1)
 	       {
 		  temp1 = graph_[height_-y][temp2];
-		  return temp1*256;
+		  return temp1*scale8To16Bit;
 	       }
 
 	     if(colour == 2)
 	       {
 		  temp1 =  graph_[height_-y][temp2+1];
-		  return temp1*256;
+		  return temp1*scale8To16Bit;
 	       }
 
 	     if(colour == 3)
 	       {
 		  temp1 =  graph_[height_-y][temp2+2];
-		  return temp1*256;
+		  return temp1*scale8To16Bit;
 	       }
 	  }
      }

--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -766,13 +766,13 @@ int pngwriter::read(int x, int y, int colour) const
 	if(bit_depth_ == 16)
 	  {
 	     /* In these cases *256 is correct, because what we actually are
-          * doing is bitshifting by 8 bit and then appending the next lower
-          * 8 bit.
-          * These lines are inefficient. Bitshifting and bitwise anding may
-          * have better performance than multiplication and addition.
-          * We could also just convert (unsigned char*) to (uint16_t*).
-          * If the open file function does it in the same way, then this
-          * method makes no assumptions about platform endianness */
+	      * doing is bitshifting by 8 bit and then appending the next lower
+	      * 8 bit.
+	      * These lines are inefficient. Bitshifting and bitwise anding may
+	      * have better performance than multiplication and addition.
+	      * We could also just convert (unsigned char*) to (uint16_t*).
+	      * If the open file function does it in the same way, then this
+	      * method makes no assumptions about platform endianness */
 	     temp2=6*(x-1);
 	     if(colour == 1)
 	       {

--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -795,7 +795,7 @@ int pngwriter::read(int x, int y, int colour) const
 
 	if(bit_depth_ == 8)
 	  {
-	     int const scale8To16Bit = 257;   // x/255*65535 = x*257
+	     int const scale8To16Bit = 257;   // (x/255.0)*65535.0 -> x*257
 	     temp2=3*(x-1);
 	     if(colour == 1)
 	       {


### PR DESCRIPTION
Fix #89: The other appearances of `*256` seem to be some weird upscales in order to avoid floating point arithmetic. They are scaled down `/256` soon thereafter.