### PR TITLE
Refactor background fill and image data copy code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
 
+sudo: required
+dist: trusty
+
 compiler:
   - gcc
   - clang
@@ -9,21 +12,26 @@ env:
     - CXXFLAGS="-Werror -Wextra -pedantic"
     - BUILD=~/buildTmp
     - LIBPNG_DOWNLOAD=http://download.sourceforge.net/libpng/libpng-
+    - LIBFREETYPE_DOWNLOAD=http://download.savannah.gnu.org/releases/freetype/freetype-
   matrix:
-    - LIBPNG_VERSION=1.2.56 FREETYPE=ON
-    - LIBPNG_VERSION=1.2.56 FREETYPE=OFF
-    - LIBPNG_VERSION=1.4.19 FREETYPE=ON
-    - LIBPNG_VERSION=1.5.26 FREETYPE=ON
-    - LIBPNG_VERSION=1.6.21 FREETYPE=ON
-    - LIBPNG_VERSION=1.7.0beta78
+    - LIBPNG_VERSION=1.2.56 FREETYPE=OFF PERFTEST=OFF CPP11=OFF
+    - LIBPNG_VERSION=1.2.56 FREETYPE=2.4.12 PERFTEST=ON CPP11=OFF # risky due to stdlib 98/11 incomp.
+    - LIBPNG_VERSION=1.2.56 FREETYPE=2.4.12 PERFTEST=ON CPP11=ON
+    - LIBPNG_VERSION=1.4.19 FREETYPE=2.4.12 PERFTEST=OFF CPP11=OFF
+    - LIBPNG_VERSION=1.5.26 FREETYPE=2.5.5 PERFTEST=OFF CPP11=OFF
+    - LIBPNG_VERSION=1.6.21 FREETYPE=2.6.3 PERFTEST=OFF CPP11=OFF
+    - LIBPNG_VERSION=1.7.0beta80 FREETYPE=2.6.3 PERFTEST=OFF CPP11=OFF
 
 matrix:
   allow_failures:
-    - env: LIBPNG_VERSION=1.7.0beta78
+    - env: LIBPNG_VERSION=1.7.0beta80 FREETYPE=2.6.3 PERFTEST=OFF CPP11=OFF
 
 script:
   - cd $BUILD
-  - cmake $TRAVIS_BUILD_DIR
+  - if [ "$CPP11" == "ON" ]; then
+      export CXXFLAGS="$CXXFLAGS -std=c++11";
+    fi
+  - cmake -DBUILD_PERFORMANCE=$PERFTEST $TRAVIS_BUILD_DIR
   - make
   - sudo make install
 # tests
@@ -37,6 +45,10 @@ script:
   - ./blackwhite bw_8bit_rgb_20x20.png
   # read channel range test (black-white, grayscale)
   # to do
+  # performance test
+  - if [ "$PERFTEST" == "ON" ]; then 
+      ./performance;
+    fi
 
 before_script:
   - uname -r
@@ -44,10 +56,13 @@ before_script:
 # kick without checking dependencies
   - sudo dpkg -r --force-depends libpng12-dev
   - sudo dpkg -r --force-depends libpng12-0
-  - if [ "$FREETYPE" == "OFF" ]; then sudo dpkg -r --force-depends libfreetype6; sudo rm -rf /usr/include/freetype* /usr/lib/x86_64-linux-gnu/libfreetype*; fi
+  - sudo dpkg -r --force-depends libfreetype6-dev
+  - sudo dpkg -r --force-depends libfreetype6
+  - sudo rm -rf /usr/include/freetype* /usr/lib/x86_64-linux-gnu/libfreetype*
   - sudo rm -rf /usr/include/libpng12 /usr/include/png*.h /usr/lib/x86_64-linux-gnu/libpng*
-#  - sudo apt-get remove -qq libpng12-0 libpng12-0:i386
+#  - sudo apt-get remove -qq libpng12-0 libpng14-0:i386
   - sudo dpkg --get-selections
+# BUILD libpng
   - wget "$LIBPNG_DOWNLOAD$LIBPNG_VERSION.tar.xz"
   - tar -xJf libpng-$LIBPNG_VERSION.tar.xz
   - cd libpng-$LIBPNG_VERSION
@@ -55,5 +70,17 @@ before_script:
   - ./configure --prefix=/usr
   - make
   - sudo make install
+  - cd ..
   - sudo find /usr/lib -name 'libpng*'
+# BUILD libfreetype (depends on libpng)
+  - if [ "$FREETYPE" != "OFF" ]; then
+      wget "$LIBFREETYPE_DOWNLOAD$FREETYPE.tar.gz";
+      tar -xzf freetype-$FREETYPE.tar.gz;
+      cd freetype-$FREETYPE;
+      ./configure --prefix=/usr;
+      make; sudo make install;
+      cd ..;
+    fi
+  - sudo find /usr/lib -name 'libfreetype*'
+# create build dir
   - mkdir -p $BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 
 # Projekt name ################################################################
 #
@@ -11,6 +11,11 @@ ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 # set helper pathes to find libraries and packages on some 64bit machines
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/")
+
+# Compiler supports C++11?
+#
+# CMake 3.1.0+:
+# is `-std=c++11` in `${CMAKE_CXX_COMPILE_FEATURES}`
 
 # Warnings ####################################################################
 #
@@ -74,8 +79,11 @@ TARGET_LINK_LIBRARIES(pngwriter_static m ${ZLIB_LIBRARIES} ${PNG_LIBRARIES} ${FR
 # build examples and tests
 SET(EXAMPLES_LIBS pngwriter_static ${FREETYPE_LIBRARIES})
 FILE(GLOB EXAMPLES_SOURCES ${EXAMPLES_SOURCES}/*.cc ${TESTS_SOURCES}/*.cc)
-# needs CXXFLAGS="-std=c++11"
-LIST(REMOVE_ITEM EXAMPLES_SOURCES "${TESTS_SOURCES}/performance.cc")
+
+OPTION(BUILD_PERFORMANCE "Build the performance measurement test (needs C++11)" OFF)
+IF(NOT BUILD_PERFORMANCE)
+    LIST(REMOVE_ITEM EXAMPLES_SOURCES "${TESTS_SOURCES}/performance.cc")
+ENDIF()
 
 FOREACH(EXAMPLEFILE ${EXAMPLES_SOURCES})
     GET_FILENAME_COMPONENT(examplename ${EXAMPLEFILE} NAME)
@@ -85,6 +93,12 @@ FOREACH(EXAMPLEFILE ${EXAMPLES_SOURCES})
 
     ADD_EXECUTABLE(${examplename} ${EXAMPLEFILE})
     TARGET_LINK_LIBRARIES(${examplename} ${EXAMPLES_LIBS})
+
+    if("${examplename}" STREQUAL "performance")
+        TARGET_COMPILE_OPTIONS(performance PRIVATE -std=c++11)
+        # CMake 3.1.0+:
+        #SET_PROPERTY(TARGET performance PROPERTY CXX_STANDARD 11)
+    endif()
 ENDFOREACH(EXAMPLEFILE ${EXAMPLES_SOURCES})
 
 # Copy example files to "build" dir for easy testing ##########################

--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -88,21 +88,7 @@ pngwriter::pngwriter()
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-      for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //graph_[vhhh][6*hhh + i] where i goes from 0 to 5
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
+   fillBackgroundColor();
 }
 
 //Copy Constructor
@@ -148,22 +134,7 @@ pngwriter::pngwriter(const pngwriter &rhs)
      {
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //   graph_[vhhh][6*hhh + i ] i=0 to 5
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = rhs.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = rhs.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = rhs.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = rhs.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = rhs.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = rhs.graph_[vhhh][tempindex+5];
-	  }
-     }
-
+   copyImageDataFrom(rhs.graph_, graph_, height_, width_);
 }
 
 //Constructor for int colour levels, char * filename
@@ -228,29 +199,7 @@ pngwriter::pngwriter(int x, int y, int backgroundcolour, char * filename)
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   if(backgroundcolour_ == 0)
-     for(int vhhh = 0; vhhh<height_;vhhh++)
-       memset( graph_[vhhh],
-               (char) backgroundcolour_,
-               width_*6 );
-   else
-   {
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //graph_[vhhh][6*hhh + i] i = 0  to 5
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
-   }
+   fillBackgroundColor();
 }
 
 //Constructor for double levels, char * filename
@@ -315,29 +264,7 @@ pngwriter::pngwriter(int x, int y, double backgroundcolour, char * filename)
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   if(backgroundcolour_ == 0)
-     for(int vhhh = 0; vhhh<height_;vhhh++)
-       memset( graph_[vhhh],
-               (char) backgroundcolour_,
-               width_*6 );
-   else
-   {
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     // graph_[vhhh][tempindex + i] where i = 0 to 5
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
-   }
+   fillBackgroundColor();
 }
 
 void pngwriter::deleteMembers()
@@ -424,29 +351,7 @@ pngwriter::pngwriter(int x, int y, int backgroundcolour, const char * filename)
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   if(backgroundcolour_ == 0)
-     for(int vhhh = 0; vhhh<height_;vhhh++)
-       memset( graph_[vhhh],
-               (char) backgroundcolour_,
-               width_*6 );
-   else
-   {
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //graph_[vhhh][6*hhh + i] where i = 0 to 5
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
-   }
+   fillBackgroundColor();
 }
 
 //Constructor for double levels, const char * filename
@@ -511,96 +416,51 @@ pngwriter::pngwriter(int x, int y, double backgroundcolour, const char * filenam
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   if(backgroundcolour_ == 0)
-     for(int vhhh = 0; vhhh<height_;vhhh++)
-       memset( graph_[vhhh],
-               (char) backgroundcolour_,
-               width_*6 );
-   else
-   {
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //etc
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
-   }
+   fillBackgroundColor();
 }
 
 // Overloading operator =
-/////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////
+// Note: In a future version that breaks ABI compatibilty, this should be
+// changed to a proper copy and swap solution.  When that time comes, this
+// function should be replace with this code -
+//
+//   pngwriter & pngwriter::operator = (pngwriter rhs)
+//   {
+//     swap(*this, rhs);
+//     return *this;
+//   }
+//////////////////////////////////////////////////////////////////////////
 pngwriter & pngwriter::operator = (const pngwriter & rhs)
 {
-   if( this==&rhs)
-      return *this;
+  pngwriter temp(rhs);
+  swap(*this, temp);
+  return *this;
+}
 
-   // free old allocations from member variables
-   deleteMembers();
+// Public friend of pngwriter
+void swap(pngwriter & lhs, pngwriter & rhs)
+{
+  using namespace std;
 
-   width_ = rhs.width_;
-   height_ = rhs.height_;
-   backgroundcolour_ = rhs.backgroundcolour_;
-   compressionlevel_ = rhs.compressionlevel_;
-   filegamma_ = rhs.filegamma_;
-   transformation_ = rhs.transformation_;
+  swap(lhs.width_, rhs.width_);
+  swap(lhs.height_,rhs.height_);
+  swap(lhs.backgroundcolour_, rhs.backgroundcolour_);
+  swap(lhs.compressionlevel_, rhs.compressionlevel_);
+  swap(lhs.filegamma_, rhs.filegamma_);
+  swap(lhs.transformation_, rhs.transformation_);
 
-   textauthor_ = rhs.textauthor_;
-   textdescription_ = rhs.textdescription_;
-   textsoftware_ = rhs.textsoftware_;
-   texttitle_ = rhs.texttitle_;
-   filename_ = rhs.filename_;
+  swap(lhs.filename_, rhs.filename_);
+  swap(lhs.textauthor_, rhs.textauthor_);
+  swap(lhs.textdescription_, rhs.textdescription_);
+  swap(lhs.textsoftware_, rhs.textsoftware_);
+  swap(lhs.texttitle_, rhs.texttitle_);
 
-   int kkkk;
+  swap(lhs.bit_depth_, rhs.bit_depth_);
+  swap(lhs.colortype_, rhs.colortype_);
+  swap(lhs.screengamma_, rhs.screengamma_);
 
-   bit_depth_ = rhs.bit_depth_;
-   colortype_= rhs.colortype_;
-   screengamma_ = rhs.screengamma_;
-
-   graph_ = (png_bytepp)malloc(height_ * sizeof(png_bytep));
-   if(graph_ == NULL)
-     {
-	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
-     }
-
-   for (kkkk = 0; kkkk < height_; kkkk++)
-     {
-        graph_[kkkk] = (png_bytep)malloc(6*width_ * sizeof(png_byte));
-	if(graph_[kkkk] == NULL)
-	  {
-	     std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
-	  }
-     }
-
-   if(graph_ == NULL)
-     {
-	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
-     }
-
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = rhs.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = rhs.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = rhs.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = rhs.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = rhs.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = rhs.graph_[vhhh][tempindex+5];
-	  }
-     }
-
-   return *this;
+  swap(lhs.graph_, rhs.graph_);
 }
 
 ///////////////////////////////////////////////////////////////
@@ -2866,22 +2726,7 @@ void pngwriter::resize(int width, int height)
      {
 	std::cerr << " PNGwriter::resize - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
-
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //graph_[vhhh][6*hhh + i] where i goes from 0 to 5
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
+   fillBackgroundColor();
 }
 
 void pngwriter::boundary_fill(int xstart, int ystart, double boundary_red,double boundary_green,double boundary_blue,double fill_red, double fill_green, double fill_blue)
@@ -3245,20 +3090,8 @@ void pngwriter::scale_k(double k)
    //This instance now has a new, resized storage space.
 
    //Copy the temp date into this's storage.
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = temp.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = temp.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = temp.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = temp.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = temp.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = temp.graph_[vhhh][tempindex+5];
-	  }
-     }
+
+   copyImageDataFrom(temp.graph_, graph_, height_, width_);
 
    // this should now contain the new, scaled image data.
    //
@@ -3336,20 +3169,8 @@ void pngwriter::scale_kxky(double kx, double ky)
    //This instance now has a new, resized storage space.
 
    //Copy the temp date into this's storage.
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = temp.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = temp.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = temp.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = temp.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = temp.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = temp.graph_[vhhh][tempindex+5];
-	  }
-     }
+
+   copyImageDataFrom(temp.graph_, graph_, height_, width_);
 
    // this should now contain the new, scaled image data.
    //
@@ -3425,20 +3246,8 @@ void pngwriter::scale_wh(int finalwidth, int finalheight)
    //This instance now has a new, resized storage space.
 
    //Copy the temp date into this's storage.
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = temp.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = temp.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = temp.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = temp.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = temp.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = temp.graph_[vhhh][tempindex+5];
-	  }
-     }
+
+   copyImageDataFrom(temp.graph_, graph_, height_, width_);
 
    // this should now contain the new, scaled image data.
    //
@@ -4758,4 +4567,59 @@ void pngwriter::filleddiamond( int x, int y, int width, int height, double red, 
 void pngwriter::diamond( int x, int y, int width, int height, double red, double green, double blue)
 {
    this->diamond(  x,  y,  width,  height, int(red*65535), int(green*65535), int(blue*65535) );
+}
+
+int pngwriter::fillBackgroundColor(void)
+{
+  return fillBackgroundWithColor(backgroundcolour_);
+}
+
+int pngwriter::fillBackgroundWithColor(int color)
+{
+  if(color == 0)
+    for(int vhhh = 0; vhhh<height_;vhhh++)
+      memset( graph_[vhhh],
+             (char) color,
+             width_*6 );
+  else
+  {
+    for(int vhhh = 0; vhhh<height_;vhhh++)
+    {
+      for(int hhh = 0; hhh<width_;hhh++)
+      {
+        //graph_[vhhh][6*hhh + i] i = 0  to 5
+        int tempindex = 6*hhh;
+        graph_[vhhh][tempindex] = (char) floor(((double)color)/256);
+        graph_[vhhh][tempindex+1] = (char)(color%256);
+        graph_[vhhh][tempindex+2] = (char) floor(((double)color)/256);
+        graph_[vhhh][tempindex+3] = (char)(color%256);
+        graph_[vhhh][tempindex+4] = (char) floor(((double)color)/256);
+        graph_[vhhh][tempindex+5] = (char)(color%256);
+      }
+    }
+  }
+  backgroundcolour_ = color;
+  return 0;
+}
+
+int pngwriter::copyImageDataFrom(unsigned char ** const source_graph,
+                                 unsigned char ** dest_graph,
+                                 int height, int width)
+{
+  for(int vhhh = 0; vhhh<height;vhhh++)
+  {
+    for(int hhh = 0; hhh<width;hhh++)
+    {
+      //   graph_[vhhh][6*hhh + i ] i=0 to 5
+      int tempindex=6*hhh;
+      dest_graph[vhhh][tempindex] = source_graph[vhhh][tempindex];
+      dest_graph[vhhh][tempindex+1] = source_graph[vhhh][tempindex+1];
+      dest_graph[vhhh][tempindex+2] = source_graph[vhhh][tempindex+2];
+      dest_graph[vhhh][tempindex+3] = source_graph[vhhh][tempindex+3];
+      dest_graph[vhhh][tempindex+4] = source_graph[vhhh][tempindex+4];
+      dest_graph[vhhh][tempindex+5] = source_graph[vhhh][tempindex+5];
+    }
+  }
+  
+  return -1;
 }

--- a/src/pngwriter.h
+++ b/src/pngwriter.h
@@ -136,6 +136,10 @@ class pngwriter
 
    /* free up memory of member variables and reset internal pointers to NULL */
    void deleteMembers();
+
+   /* Fill image with background color */
+    int setBackgroundWithColor(int color);
+
  public:
 
    /* General Notes
@@ -195,6 +199,8 @@ class pngwriter
    /* Assignment Operator
     * */
    pngwriter & operator = (const pngwriter & rhs);
+
+   friend void swap(pngwriter & lhs, pngwriter & rhs);
 
    /*  Plot
     * With this function a pixel at coordinates (x, y) can be set to the desired colour.
@@ -732,6 +738,12 @@ class pngwriter
 
    int static get_text_width_utf8(char * face_path, int fontsize, char * text);
 
+   int fillBackgroundColor(void);
+   int fillBackgroundWithColor(int color);
+
+   static int copyImageDataFrom(unsigned char ** const source_graph,
+                                unsigned char ** dest_graph,
+                                int height, int width);
 
 };
 


### PR DESCRIPTION
Cleans up code that does the background fill operations and functions which copy pngwriter image data
from source object to destination object (graph_).  Also, updated the operator = to a near proper
copy-and-swap idiom (note added in comments on making it fully proper and C++11 ready).

Here's the before and after benchmarks of running "performance.cc" in release mode with an
image size of 10000 x 10000 and background color set to 4.

```
                        Before      After
                       Refactor    Refactor   Improvement
-----------------------+----------+----------+-----------
allocation time:       |   928461 |   472277 | 0.5087
random value time:     |  2352986 |  2275185 | 0.9669
png copy (in RAM) time:|   915583 |   689525 | 0.7531
png scale_k(0.5) time: |  2550104 |  2500438 | 0.9805
png scale_k(2.0) time: | 40625981 | 39492986 | 0.9721
write_png() time:      | 25782479 | 26071078 | 1.0112
```

Will continue to provide updated benchmarks as refactoring continues.  

I don't think the changes made break ABI compatibility.  If that's a concern, maybe someone can test for that.  Once I get more into the project and get some compiled samples put together I can check for breakage then.