### PR TITLE
CMake: Add Option to Build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
 
+sudo: required
+dist: trusty
+
 compiler:
   - gcc
   - clang
@@ -9,21 +12,26 @@ env:
     - CXXFLAGS="-Werror -Wextra -pedantic"
     - BUILD=~/buildTmp
     - LIBPNG_DOWNLOAD=http://download.sourceforge.net/libpng/libpng-
+    - LIBFREETYPE_DOWNLOAD=http://download.savannah.gnu.org/releases/freetype/freetype-
   matrix:
-    - LIBPNG_VERSION=1.2.56 FREETYPE=ON
-    - LIBPNG_VERSION=1.2.56 FREETYPE=OFF
-    - LIBPNG_VERSION=1.4.19 FREETYPE=ON
-    - LIBPNG_VERSION=1.5.26 FREETYPE=ON
-    - LIBPNG_VERSION=1.6.21 FREETYPE=ON
-    - LIBPNG_VERSION=1.7.0beta78
+    - LIBPNG_VERSION=1.2.56 FREETYPE=OFF PERFTEST=OFF CPP11=OFF
+    - LIBPNG_VERSION=1.2.56 FREETYPE=2.4.12 PERFTEST=ON CPP11=OFF # risky due to stdlib 98/11 incomp.
+    - LIBPNG_VERSION=1.2.56 FREETYPE=2.4.12 PERFTEST=ON CPP11=ON
+    - LIBPNG_VERSION=1.4.19 FREETYPE=2.4.12 PERFTEST=OFF CPP11=OFF
+    - LIBPNG_VERSION=1.5.26 FREETYPE=2.5.5 PERFTEST=OFF CPP11=OFF
+    - LIBPNG_VERSION=1.6.21 FREETYPE=2.6.3 PERFTEST=OFF CPP11=OFF
+    - LIBPNG_VERSION=1.7.0beta80 FREETYPE=2.6.3 PERFTEST=OFF CPP11=OFF
 
 matrix:
   allow_failures:
-    - env: LIBPNG_VERSION=1.7.0beta78
+    - env: LIBPNG_VERSION=1.7.0beta80 FREETYPE=2.6.3 PERFTEST=OFF CPP11=OFF
 
 script:
   - cd $BUILD
-  - cmake $TRAVIS_BUILD_DIR
+  - if [ "$CPP11" == "ON" ]; then
+      export CXXFLAGS="$CXXFLAGS -std=c++11";
+    fi
+  - cmake -DBUILD_PERFORMANCE=$PERFTEST $TRAVIS_BUILD_DIR
   - make
   - sudo make install
 # tests
@@ -37,6 +45,10 @@ script:
   - ./blackwhite bw_8bit_rgb_20x20.png
   # read channel range test (black-white, grayscale)
   # to do
+  # performance test
+  - if [ "$PERFTEST" == "ON" ]; then 
+      ./performance;
+    fi
 
 before_script:
   - uname -r
@@ -44,10 +56,13 @@ before_script:
 # kick without checking dependencies
   - sudo dpkg -r --force-depends libpng12-dev
   - sudo dpkg -r --force-depends libpng12-0
-  - if [ "$FREETYPE" == "OFF" ]; then sudo dpkg -r --force-depends libfreetype6; sudo rm -rf /usr/include/freetype* /usr/lib/x86_64-linux-gnu/libfreetype*; fi
+  - sudo dpkg -r --force-depends libfreetype6-dev
+  - sudo dpkg -r --force-depends libfreetype6
+  - sudo rm -rf /usr/include/freetype* /usr/lib/x86_64-linux-gnu/libfreetype*
   - sudo rm -rf /usr/include/libpng12 /usr/include/png*.h /usr/lib/x86_64-linux-gnu/libpng*
-#  - sudo apt-get remove -qq libpng12-0 libpng12-0:i386
+#  - sudo apt-get remove -qq libpng12-0 libpng14-0:i386
   - sudo dpkg --get-selections
+# BUILD libpng
   - wget "$LIBPNG_DOWNLOAD$LIBPNG_VERSION.tar.xz"
   - tar -xJf libpng-$LIBPNG_VERSION.tar.xz
   - cd libpng-$LIBPNG_VERSION
@@ -55,5 +70,17 @@ before_script:
   - ./configure --prefix=/usr
   - make
   - sudo make install
+  - cd ..
   - sudo find /usr/lib -name 'libpng*'
+# BUILD libfreetype (depends on libpng)
+  - if [ "$FREETYPE" != "OFF" ]; then
+      wget "$LIBFREETYPE_DOWNLOAD$FREETYPE.tar.gz";
+      tar -xzf freetype-$FREETYPE.tar.gz;
+      cd freetype-$FREETYPE;
+      ./configure --prefix=/usr;
+      make; sudo make install;
+      cd ..;
+    fi
+  - sudo find /usr/lib -name 'libfreetype*'
+# create build dir
   - mkdir -p $BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 
 # Projekt name ################################################################
 #
@@ -11,6 +11,11 @@ ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 # set helper pathes to find libraries and packages on some 64bit machines
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/")
+
+# Compiler supports C++11?
+#
+# CMake 3.1.0+:
+# is `-std=c++11` in `${CMAKE_CXX_COMPILE_FEATURES}`
 
 # Warnings ####################################################################
 #
@@ -74,8 +79,11 @@ TARGET_LINK_LIBRARIES(pngwriter_static m ${ZLIB_LIBRARIES} ${PNG_LIBRARIES} ${FR
 # build examples and tests
 SET(EXAMPLES_LIBS pngwriter_static ${FREETYPE_LIBRARIES})
 FILE(GLOB EXAMPLES_SOURCES ${EXAMPLES_SOURCES}/*.cc ${TESTS_SOURCES}/*.cc)
-# needs CXXFLAGS="-std=c++11"
-LIST(REMOVE_ITEM EXAMPLES_SOURCES "${TESTS_SOURCES}/performance.cc")
+
+OPTION(BUILD_PERFORMANCE "Build the performance measurement test (needs C++11)" OFF)
+IF(NOT BUILD_PERFORMANCE)
+    LIST(REMOVE_ITEM EXAMPLES_SOURCES "${TESTS_SOURCES}/performance.cc")
+ENDIF()
 
 FOREACH(EXAMPLEFILE ${EXAMPLES_SOURCES})
     GET_FILENAME_COMPONENT(examplename ${EXAMPLEFILE} NAME)
@@ -85,6 +93,12 @@ FOREACH(EXAMPLEFILE ${EXAMPLES_SOURCES})
 
     ADD_EXECUTABLE(${examplename} ${EXAMPLEFILE})
     TARGET_LINK_LIBRARIES(${examplename} ${EXAMPLES_LIBS})
+
+    if("${examplename}" STREQUAL "performance")
+        TARGET_COMPILE_OPTIONS(performance PRIVATE -std=c++11)
+        # CMake 3.1.0+:
+        #SET_PROPERTY(TARGET performance PROPERTY CXX_STANDARD 11)
+    endif()
 ENDFOREACH(EXAMPLEFILE ${EXAMPLES_SOURCES})
 
 # Copy example files to "build" dir for easy testing ##########################


### PR DESCRIPTION
Adds an option to build the performance test which requires C++11:
```bash
cmake -DBUILD_PERFORMANCE=ON ~/path/to/src
make
```

- updates CMake to 2.8.12 (3.1+ would be more convenient for an auto-enable on C++11 found, but is still too recent for shipping)
- updates travis to trusty builds
- adds full and partial (performance) C++11 builds