### PR TITLE
Refactor background fills and image copy

### DIFF
--- a/src/pngwriter.cc
+++ b/src/pngwriter.cc
@@ -88,21 +88,7 @@ pngwriter::pngwriter()
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-      for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //graph_[vhhh][6*hhh + i] where i goes from 0 to 5
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
+   fillBackgroundColor_16(backgroundcolour_);
 }
 
 //Copy Constructor
@@ -148,22 +134,7 @@ pngwriter::pngwriter(const pngwriter &rhs)
      {
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //   graph_[vhhh][6*hhh + i ] i=0 to 5
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = rhs.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = rhs.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = rhs.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = rhs.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = rhs.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = rhs.graph_[vhhh][tempindex+5];
-	  }
-     }
-
+   copyImageDataFrom(rhs.graph_, graph_, height_, width_);
 }
 
 //Constructor for int colour levels, char * filename
@@ -228,29 +199,7 @@ pngwriter::pngwriter(int x, int y, int backgroundcolour, char * filename)
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   if(backgroundcolour_ == 0)
-     for(int vhhh = 0; vhhh<height_;vhhh++)
-       memset( graph_[vhhh],
-               (char) backgroundcolour_,
-               width_*6 );
-   else
-   {
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //graph_[vhhh][6*hhh + i] i = 0  to 5
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
-   }
+   fillBackgroundColor_16(backgroundcolour_);
 }
 
 //Constructor for double levels, char * filename
@@ -315,29 +264,7 @@ pngwriter::pngwriter(int x, int y, double backgroundcolour, char * filename)
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   if(backgroundcolour_ == 0)
-     for(int vhhh = 0; vhhh<height_;vhhh++)
-       memset( graph_[vhhh],
-               (char) backgroundcolour_,
-               width_*6 );
-   else
-   {
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     // graph_[vhhh][tempindex + i] where i = 0 to 5
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
-   }
+   fillBackgroundColor_16(backgroundcolour_);
 }
 
 void pngwriter::deleteMembers()
@@ -424,29 +351,7 @@ pngwriter::pngwriter(int x, int y, int backgroundcolour, const char * filename)
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   if(backgroundcolour_ == 0)
-     for(int vhhh = 0; vhhh<height_;vhhh++)
-       memset( graph_[vhhh],
-               (char) backgroundcolour_,
-               width_*6 );
-   else
-   {
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //graph_[vhhh][6*hhh + i] where i = 0 to 5
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
-   }
+   fillBackgroundColor_16(backgroundcolour_);
 }
 
 //Constructor for double levels, const char * filename
@@ -511,96 +416,51 @@ pngwriter::pngwriter(int x, int y, double backgroundcolour, const char * filenam
 	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
 
-   if(backgroundcolour_ == 0)
-     for(int vhhh = 0; vhhh<height_;vhhh++)
-       memset( graph_[vhhh],
-               (char) backgroundcolour_,
-               width_*6 );
-   else
-   {
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //etc
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
-   }
+   fillBackgroundColor_16(backgroundcolour_);
 }
 
 // Overloading operator =
-/////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////
+// Note: In a future version that breaks ABI compatibilty, this should be
+// changed to a proper copy and swap solution.  When that time comes, this
+// function should be replace with this code -
+//
+//   pngwriter & pngwriter::operator = (pngwriter rhs)
+//   {
+//     swap(*this, rhs);
+//     return *this;
+//   }
+//////////////////////////////////////////////////////////////////////////
 pngwriter & pngwriter::operator = (const pngwriter & rhs)
 {
-   if( this==&rhs)
-      return *this;
+  pngwriter temp(rhs);
+  swap(*this, temp);
+  return *this;
+}
 
-   // free old allocations from member variables
-   deleteMembers();
+// Public friend of pngwriter
+void swap(pngwriter & lhs, pngwriter & rhs)
+{
+  using namespace std;
 
-   width_ = rhs.width_;
-   height_ = rhs.height_;
-   backgroundcolour_ = rhs.backgroundcolour_;
-   compressionlevel_ = rhs.compressionlevel_;
-   filegamma_ = rhs.filegamma_;
-   transformation_ = rhs.transformation_;
+  swap(lhs.width_, rhs.width_);
+  swap(lhs.height_,rhs.height_);
+  swap(lhs.backgroundcolour_, rhs.backgroundcolour_);
+  swap(lhs.compressionlevel_, rhs.compressionlevel_);
+  swap(lhs.filegamma_, rhs.filegamma_);
+  swap(lhs.transformation_, rhs.transformation_);
 
-   textauthor_ = rhs.textauthor_;
-   textdescription_ = rhs.textdescription_;
-   textsoftware_ = rhs.textsoftware_;
-   texttitle_ = rhs.texttitle_;
-   filename_ = rhs.filename_;
+  swap(lhs.filename_, rhs.filename_);
+  swap(lhs.textauthor_, rhs.textauthor_);
+  swap(lhs.textdescription_, rhs.textdescription_);
+  swap(lhs.textsoftware_, rhs.textsoftware_);
+  swap(lhs.texttitle_, rhs.texttitle_);
 
-   int kkkk;
+  swap(lhs.bit_depth_, rhs.bit_depth_);
+  swap(lhs.colortype_, rhs.colortype_);
+  swap(lhs.screengamma_, rhs.screengamma_);
 
-   bit_depth_ = rhs.bit_depth_;
-   colortype_= rhs.colortype_;
-   screengamma_ = rhs.screengamma_;
-
-   graph_ = (png_bytepp)malloc(height_ * sizeof(png_bytep));
-   if(graph_ == NULL)
-     {
-	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
-     }
-
-   for (kkkk = 0; kkkk < height_; kkkk++)
-     {
-        graph_[kkkk] = (png_bytep)malloc(6*width_ * sizeof(png_byte));
-	if(graph_[kkkk] == NULL)
-	  {
-	     std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
-	  }
-     }
-
-   if(graph_ == NULL)
-     {
-	std::cerr << " PNGwriter::pngwriter - ERROR **:  Not able to allocate memory for image." << std::endl;
-     }
-
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = rhs.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = rhs.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = rhs.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = rhs.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = rhs.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = rhs.graph_[vhhh][tempindex+5];
-	  }
-     }
-
-   return *this;
+  swap(lhs.graph_, rhs.graph_);
 }
 
 ///////////////////////////////////////////////////////////////
@@ -2866,22 +2726,7 @@ void pngwriter::resize(int width, int height)
      {
 	std::cerr << " PNGwriter::resize - ERROR **:  Not able to allocate memory for image." << std::endl;
      }
-
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     //graph_[vhhh][6*hhh + i] where i goes from 0 to 5
-	     tempindex = 6*hhh;
-	     graph_[vhhh][tempindex] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+1] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+2] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+3] = (char)(backgroundcolour_%256);
-	     graph_[vhhh][tempindex+4] = (char) floor(((double)backgroundcolour_)/256);
-	     graph_[vhhh][tempindex+5] = (char)(backgroundcolour_%256);
-	  }
-     }
+   fillBackgroundColor_16(backgroundcolour_);
 }
 
 void pngwriter::boundary_fill(int xstart, int ystart, double boundary_red,double boundary_green,double boundary_blue,double fill_red, double fill_green, double fill_blue)
@@ -3245,20 +3090,8 @@ void pngwriter::scale_k(double k)
    //This instance now has a new, resized storage space.
 
    //Copy the temp date into this's storage.
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = temp.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = temp.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = temp.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = temp.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = temp.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = temp.graph_[vhhh][tempindex+5];
-	  }
-     }
+
+   copyImageDataFrom(temp.graph_, graph_, height_, width_);
 
    // this should now contain the new, scaled image data.
    //
@@ -3336,20 +3169,8 @@ void pngwriter::scale_kxky(double kx, double ky)
    //This instance now has a new, resized storage space.
 
    //Copy the temp date into this's storage.
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = temp.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = temp.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = temp.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = temp.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = temp.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = temp.graph_[vhhh][tempindex+5];
-	  }
-     }
+
+   copyImageDataFrom(temp.graph_, graph_, height_, width_);
 
    // this should now contain the new, scaled image data.
    //
@@ -3425,20 +3246,8 @@ void pngwriter::scale_wh(int finalwidth, int finalheight)
    //This instance now has a new, resized storage space.
 
    //Copy the temp date into this's storage.
-   int tempindex;
-   for(int vhhh = 0; vhhh<height_;vhhh++)
-     {
-       for(int hhh = 0; hhh<width_;hhh++)
-	  {
-	     tempindex=6*hhh;
-	     graph_[vhhh][tempindex] = temp.graph_[vhhh][tempindex];
-	     graph_[vhhh][tempindex+1] = temp.graph_[vhhh][tempindex+1];
-	     graph_[vhhh][tempindex+2] = temp.graph_[vhhh][tempindex+2];
-	     graph_[vhhh][tempindex+3] = temp.graph_[vhhh][tempindex+3];
-	     graph_[vhhh][tempindex+4] = temp.graph_[vhhh][tempindex+4];
-	     graph_[vhhh][tempindex+5] = temp.graph_[vhhh][tempindex+5];
-	  }
-     }
+
+   copyImageDataFrom(temp.graph_, graph_, height_, width_);
 
    // this should now contain the new, scaled image data.
    //
@@ -4758,4 +4567,78 @@ void pngwriter::filleddiamond( int x, int y, int width, int height, double red, 
 void pngwriter::diamond( int x, int y, int width, int height, double red, double green, double blue)
 {
    this->diamond(  x,  y,  width,  height, int(red*65535), int(green*65535), int(blue*65535) );
+}
+
+png_color_struct pngwriter::decode_16bit_rgb565_channels(png_uint_16 color)
+{
+  png_color_struct rgb_color = {
+    static_cast<png_byte>((((color & 0xF800) >> 11) * 527 + 23) >> 6),
+    static_cast<png_byte>((((color & 0x07E0) >> 5) * 259 + 33) >> 6),
+    static_cast<png_byte>(((color & 0x001f) * 527 + 23) >> 6)
+    };
+    return rgb_color;
+}
+
+png_color_struct pngwriter::decode_16bit_rgb555_channels(png_uint_16 color)
+{
+  png_color_struct rgb_color = {
+    static_cast<png_byte>((((color & 0x7C00) >> 10) * 527 + 23) >> 6),
+    static_cast<png_byte>((((color & 0x03E0) >> 5) * 527 + 23) >> 6),
+    static_cast<png_byte>(((color & 0x001f) * 527 + 23) >> 6)
+    };
+    return rgb_color;
+}
+
+void pngwriter::fillBackgroundColor_16(png_uint_16 color, bool bRGB565)
+{
+  if(bRGB565)
+  {
+      fillBackgroundWithRGBColor(decode_16bit_rgb565_channels(color));
+  } else {
+      fillBackgroundWithRGBColor(decode_16bit_rgb555_channels(color));
+  }
+}
+
+void pngwriter::fillBackgroundWithRGBColor(const png_color_struct rgb_color)
+{
+  if(rgb_color.red == rgb_color.green && rgb_color.red == rgb_color.blue)
+  {
+    // All channel values are equal, use faster memset
+    for(int vhhh = 0; vhhh<height_;vhhh++)
+    {
+      memset( graph_[vhhh], rgb_color.red, width_*6 );
+    }
+    return;
+  }
+
+  for (int vhhh = 0; vhhh < height_; vhhh++)
+  {
+    png_uint_16p buffer = (png_uint_16p) *(&graph_[vhhh]);
+    for(int hhh = 0; hhh < width_; ++hhh)
+    {
+      *buffer++ = rgb_color.red;
+      *buffer++ = rgb_color.green;
+      *buffer++ = rgb_color.blue;
+    }
+  }
+}
+
+void pngwriter::copyImageDataFrom(unsigned char ** const source_graph,
+                                 unsigned char ** dest_graph,
+                                 int height, int width)
+{
+  if(*source_graph == *dest_graph)
+    return;
+
+  for(int vhhh = 0; vhhh<height;vhhh++)
+  {
+    png_uint_16p dest = (png_uint_16p) *(&dest_graph[vhhh]);
+    png_uint_16p source = (png_uint_16p) *(&source_graph[vhhh]);
+    for(int hhh = 0; hhh<width;hhh++)
+    {
+      *dest++ = *source++;
+      *dest++ = *source++;
+      *dest++ = *source++;
+    }
+  }
 }

--- a/src/pngwriter.h
+++ b/src/pngwriter.h
@@ -136,6 +136,47 @@ class pngwriter
 
    /* free up memory of member variables and reset internal pointers to NULL */
    void deleteMembers();
+
+   /* Fill 16 bit image background color using either RGB555 or RGB565 formatting
+    * Defaults to RGB565 formatting
+    *
+    *   http://stackoverflow.com/questions/13720937/c-defined-16bit-high-color
+    *   https://msdn.microsoft.com/en-us/library/windows/desktop/dd390989(v=vs.85).aspx
+    * */
+   void fillBackgroundColor_16(png_uint_16 color, bool bRGB565 = true);
+
+   /* Convert 16 bit RGB565 to 24 bit RGB888
+    * http://stackoverflow.com/questions/2442576/how-does-one-convert-16-bit-rgb565-to-24-bit-rgb888
+    * http://stackoverflow.com/questions/2442576/how-does-one-convert-16-bit-rgb565-to-24-bit-rgb888/9069480#9069480
+    * https://msdn.microsoft.com/en-us/library/windows/desktop/dd390989(v=vs.85).aspx
+    * Returns png_color_struct
+    *
+    * */
+   png_color_struct decode_16bit_rgb565_channels(png_uint_16 color);
+
+  /* Convert 16 bit RGB555 to 24 bit RGB888
+   * http://stackoverflow.com/questions/2442576/how-does-one-convert-16-bit-rgb565-to-24-bit-rgb888
+   * http://stackoverflow.com/questions/2442576/how-does-one-convert-16-bit-rgb565-to-24-bit-rgb888/9069480#9069480
+   * https://msdn.microsoft.com/en-us/library/windows/desktop/dd390989(v=vs.85).aspx
+   * Returns png_color_struct
+   *
+   * */
+   png_color_struct decode_16bit_rgb555_channels(png_uint_16 color);
+
+  /* Fills 16 bit image background with png_color_struct values.  Decoding of
+   * color space values should be done prior to calling this function.
+   *
+   * */
+   void fillBackgroundWithRGBColor(const png_color_struct rgb_color);
+
+   /* Copy source image data to destination image
+    * */
+   static void copyImageDataFrom(unsigned char ** const source_graph,
+                                 unsigned char ** dest_graph,
+                                 int height, int width);
+
+   friend void swap(pngwriter & lhs, pngwriter & rhs);
+
  public:
 
    /* General Notes


### PR DESCRIPTION
(Replaces PR #108)

Cleans up code that does the background fill operations and functions which copy pngwriter image data
from source object to destination object (graph_).  Also, updated the operator = to a near proper
copy-and-swap idiom (note added in comments on making it fully proper and C++11 ready).

Here's the before and after benchmarks of running "performance.cc" in release mode with an
image size of 10000 x 10000 and background color set to 4.

```
                        Before      After
                       Refactor    Refactor   Improvement
-----------------------+----------+----------+-----------
allocation time:       |   928461 |   472277 | 0.5087
random value time:     |  2352986 |  2275185 | 0.9669
png copy (in RAM) time:|   915583 |   689525 | 0.7531
png scale_k(0.5) time: |  2550104 |  2500438 | 0.9805
png scale_k(2.0) time: | 40625981 | 39492986 | 0.9721
write_png() time:      | 25782479 | 26071078 | 1.0112
```

Will continue to provide updated benchmarks as refactoring continues.  

I don't think the changes made break ABI compatibility.  If that's a concern, maybe someone can test for that.  Once I get more into the project and get some compiled samples put together I can check for breakage then.
