### PR TITLE
AppVeyor: Fix Windows Build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,86 @@
+version: "{build}"
+
+branches:
+  except:
+    - coverity_scan
+
+shallow_clone: true
+skip_tags: false
+
+platform:
+# - Win32
+  - x64
+
+build:
+  verbosity: detailed
+
+configuration:
+  - Release
+#  - Debug
+
+environment:
+  global:
+#    CXX_FLAGS: "/WX /EHsc"
+    CMAKE_PREFIX_PATH: "C:\\Sys"
+    CMAKE_LIBRARY_PATH: "C:\\Sys\\lib"
+    CMAKE_INCLUDE_PATH: "C:\\Sys\\include"
+    ZLIB_DOWNLOAD: "https://github.com/madler/zlib/archive/v"
+    LIBPNG_DOWNLOAD: "http://download.sourceforge.net/libpng/libpng-"
+    LIBFREETYPE_DOWNLOAD: "http://download.savannah.gnu.org/releases/freetype/freetype-"
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+      ZLIB_VERSION: 1.2.8
+      LIBPNG_VERSION: 1.6.21
+      FREETYPE: OFF
+      PERFTEST: OFF
+
+init:
+  - cmake --version
+  - git --version
+  - msbuild /version
+  # line endings on Windows
+  - git config --global core.autocrlf true
+
+install:
+  # zlib
+  - appveyor DownloadFile https://github.com/madler/zlib/archive/v%ZLIB_VERSION%.tar.gz
+  - 7z x v%ZLIB_VERSION%.tar.gz -so | 7z x -si -ttar
+  - cd zlib-%ZLIB_VERSION%
+  - cmake -G"%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX=C:\\Sys .
+  - cmake --build . --config %CONFIGURATION%
+  - cmake --build . --config %CONFIGURATION% --target install
+  - cd ..
+  # libpng
+  - appveyor DownloadFile %LIBPNG_DOWNLOAD%%LIBPNG_VERSION%.tar.xz
+  - 7z x libpng-%LIBPNG_VERSION%.tar.xz -so | 7z x -si -ttar
+  - cd libpng-%LIBPNG_VERSION%
+  - cmake -G"%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX=C:\\Sys .
+  - cmake --build . --config %CONFIGURATION%
+  - cmake --build . --config %CONFIGURATION% --target install
+  # go back to actual project
+  - cd ..
+
+build_script:
+  - mkdir build
+  - cd build
+  - cmake -G"%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DBUILD_PERFORMANCE=$PERFTEST -DCMAKE_INSTALL_PREFIX=C:\\pngwriter ..
+  - cmake --build . --config %CONFIGURATION%
+  - cmake --build . --config %CONFIGURATION% --target install
+# tests
+  - tree C:\\projects\pngwriter\build
+  - cd %CONFIGURATION%
+  - dir /R
+  #- pngtest.exe
+  #- readwrite.exe
+  # read channel range test (black-white, RGB)
+  #- blackwhite.exe bw_16bit_rgb_20x20.png
+  #- blackwhite.exe bw_16bit_rgba_20x20.png
+  #- blackwhite.exe bw_8bit_rgba_20x20.png
+  #- blackwhite.exe bw_8bit_rgb_20x20.png
+  # read channel range test (black-white, grayscale)
+  # to do
+  # performance test
+  #- if [ "$PERFTEST" == "ON" ]; then 
+  #    performance.exe;
+  #  fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,14 @@ INCLUDE_DIRECTORIES(${PNG_INCLUDE_DIRS})
 FIND_PACKAGE(ZLIB REQUIRED)
 INCLUDE_DIRECTORIES(${ZLIB_INCLUDE_DIRS})
 
+# external library: math from stdlib (mandatory)
+if(WIN32)
+    # automatically added on windows
+    set(MATH_LIBRARIES)
+else()
+    set(MATH_LIBRARIES m)
+endif()
+
 # external library: FreeType (optional)
 INCLUDE(FindFreetype)
 IF(FREETYPE_FOUND)
@@ -69,12 +77,12 @@ INCLUDE_DIRECTORIES(${LIBRARY_INCLUDES})
 
 # build shared library
 ADD_LIBRARY(pngwriter SHARED ${LIBRARY_SOURCES})
-TARGET_LINK_LIBRARIES(pngwriter m ${ZLIB_LIBRARIES} ${PNG_LIBRARIES} ${FREETYPE_LIBRARIES})
+TARGET_LINK_LIBRARIES(pngwriter ${MATH_LIBRARIES} ${ZLIB_LIBRARIES} ${PNG_LIBRARIES} ${FREETYPE_LIBRARIES})
 
 # build static library
 ADD_LIBRARY(pngwriter_static STATIC ${LIBRARY_SOURCES})
 SET_TARGET_PROPERTIES(pngwriter_static PROPERTIES OUTPUT_NAME pngwriter)
-TARGET_LINK_LIBRARIES(pngwriter_static m ${ZLIB_LIBRARIES} ${PNG_LIBRARIES} ${FREETYPE_LIBRARIES})
+TARGET_LINK_LIBRARIES(pngwriter_static ${MATH_LIBRARIES} ${ZLIB_LIBRARIES} ${PNG_LIBRARIES} ${FREETYPE_LIBRARIES})
 
 # build examples and tests
 SET(EXAMPLES_LIBS pngwriter_static ${FREETYPE_LIBRARIES})
@@ -108,7 +116,11 @@ FILE(COPY ${REFERENCE_PNGS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # Installation ################################################################
 #
-INSTALL(TARGETS pngwriter LIBRARY DESTINATION lib)
+if(WIN32)
+  INSTALL(TARGETS pngwriter RUNTIME DESTINATION lib)
+else()
+  INSTALL(TARGETS pngwriter LIBRARY DESTINATION lib)
+endif()
 INSTALL(TARGETS pngwriter_static ARCHIVE DESTINATION lib)
 
 # they are test binaries and should not be installed, but tested

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ PNGwriter is a C++ library for creating PNG images.
 
 [![Build Status master](https://img.shields.io/travis/pngwriter/pngwriter/master.svg?label=master)](https://travis-ci.org/pngwriter/pngwriter/branches)
 [![Build Status dev](https://img.shields.io/travis/pngwriter/pngwriter/dev.svg?label=dev)](https://travis-ci.org/pngwriter/pngwriter/branches)
+[![AppVeyor Build status dev](https://ci.appveyor.com/api/projects/status/d408e2j24ha2dopq/branch/dev?svg=true)](https://ci.appveyor.com/project/ax3l/pngwriter-2al7e/branch/dev)
 
 
 ### Summary


### PR DESCRIPTION
Fix the windows build to close #115:

- standard math library is always available
  (and will not be found if requested)
- fix install of dynamic libs:
  https://stackoverflow.com/questions/14990343/cmake-error-targets-given-no-library-destination-for-shared-library-target/37729574#37729574

And add [AppVeyor](http://appveyor.com/) windows CI.