### PR TITLE
CMake: 3.5.2+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.0.1)
+cmake_minimum_required(VERSION 3.5.2)
 
 project(PNGwriter VERSION 0.7.0 LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ export CMAKE_PREFIX_PATH=$HOME/somepath:$CMAKE_PREFIX_PATH
 
 Use the following lines in your projects `CMakeLists.txt`:
 ```cmake
-find_package(PNGwriter 0.7.0)
+find_package(PNGwriter 0.7.0 CONFIG)
 
 if(PNGwriter_FOUND)
   target_link_libraries(YourTarget PRIVATE PNGwriter::PNGwriter)


### PR DESCRIPTION
The PNG::PNG target was added in CMake 3.5.