### PR TITLE
FreeType: Image Include

### DIFF
--- a/src/pngwriter.h
+++ b/src/pngwriter.h
@@ -65,6 +65,7 @@
 #ifndef NO_FREETYPE
 #include <ft2build.h>
 #include FT_FREETYPE_H
+#include FT_IMAGE_H
 #endif
 
 #include <iostream>


### PR DESCRIPTION
Although the include for FreeType image functionality [should be pulled via `FT_FREETYPE_H` already](https://www.freetype.org/freetype2/docs/reference/ft2-header_file_macros.html#FT_IMAGE_H), it does not seem to be always present: fix #131

Since an extra include does not hurt (also in the sense of "include what you use") we can safely add this explicitly.

For the future, it would not be too bad if we could get the FreeType signatures out of our public headers (here it's the define of `FT_Bitmap`). Similar situation with zlib and libpng types. For both we just need to factor out our `private` methods into internal-only files: #57