### PR TITLE
Refactor write_to_buffer()

### DIFF
--- a/src/pngwriter.h
+++ b/src/pngwriter.h
@@ -115,6 +115,11 @@ class pngwriter
    void flood_fill_internal( int xstart, int ystart,  double start_red, double start_green, double start_blue, double fill_red, double fill_green, double fill_blue);
    void flood_fill_internal_blend( int xstart, int ystart, double opacity,  double start_red, double start_green, double start_blue, double fill_red, double fill_green, double fill_blue);
 
+
+   /* Writes the data to file or buffer.
+    */
+   void write_internal(std::vector<unsigned char> * buffer) const;
+
    /* Callback function for png_set_write_fn()
     */
    void static PngWriteVectorCallback(png_structp  png_ptr, png_bytep data, png_size_t length);


### PR DESCRIPTION
I also tried to implement a private function which replace the middle part of `close()` and `write_to_buffer()`. But the png lib use a lot of pointers which have to be valid for `png_write_*`. Therefore a function with many parameters and some declaration code in `close()` and `write_to_buffer()` is necessary.
I think, the solution in my PR is clearer than the solution I described earlier.