### PR TITLE
CMake: Honor _ROOT Env Hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,17 @@ cmake_minimum_required(VERSION 3.5.2)
 project(PNGwriter VERSION 0.7.0 LANGUAGES CXX)
 
 
+################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+
 # Options and Variants ########################################################
 #
 function(pngwriter_option name description default)

--- a/PNGwriterConfig.cmake.in
+++ b/PNGwriterConfig.cmake.in
@@ -2,6 +2,12 @@
 #   https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-a-package-configuration-file
 include(CMakeFindDependencyMacro)
 
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 find_dependency(PNG)
 find_dependency(ZLIB)
 


### PR DESCRIPTION
CMake 3.12.0+ honor `<Package>_ROOT` environment hints which are often set on HPC systems. Previously, it was only looking for `<Package>_DIR` paths in `find_package` calls.

This new policy is useful since HPC systems usually set `_DIR`, `_ROOT` or expand the `CMAKE_PREFIX_PATH`. Therefore we want to use it as soon as it is available.

On systems where those env vars are set, e.g. Hypnos, this also throws a warning if the default (OLD) policy is used with CMake 3.12.4 or newer.

References:

- https://cmake.org/cmake/help/v3.12/policy/CMP0074.html