### PR TITLE
Doc: Fix Link Order

### DIFF
--- a/doc/PNGwriterQuickReference.rtf
+++ b/doc/PNGwriterQuickReference.rtf
@@ -210,7 +210,7 @@ This would plot a red dot (1 pixel) in the lower-left corner of the image, on a 
 \
 
 \f2 g++ my_program.cc -o my_program `freetype-config --cflags` \
-	-I/usr/local/include  -L/usr/local/lib -lpng -lpngwriter -lz -lfreetype
+	-I/usr/local/include  -L/usr/local/lib -lpngwriter -lpng -lz -lfreetype
 \f1 \
 \
 Otherwise, replace 

--- a/src/pngwriter.h
+++ b/src/pngwriter.h
@@ -171,7 +171,7 @@ class pngwriter
     * A typical compilation would look like this:
     *
     * g++ my_program.cc -o my_program freetype-config --cflags \
-    *          -I/usr/local/include  -L/usr/local/lib -lpng -lpngwriter -lz -lfreetype
+    *          -I/usr/local/include  -L/usr/local/lib -lpngwriter -lpng -lz -lfreetype
     *
     * If you did not compile PNGwriter with FreeType support, then remove the
     * FreeType-related flags and add -DNO_FREETYPE above.


### PR DESCRIPTION
Manual linking of static libraries is order-dependent.
```
PNGwriter -> libPNG -> Zlib
          -> FreeType
```

Fix #139

Thanks to @johughes99 for the report!