### PR TITLE
Bump Cmake to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.0.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(PNGwriter VERSION 0.7.0 LANGUAGES CXX)
 


### PR DESCRIPTION
CMake <3.5 is not supported anymore, this bumps the version. This project does not seem to be maintained anymore but I'm leaving this PR if someone else needs it.